### PR TITLE
update package.json with current package version

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "react-native": "0.11.0",
-    "react-native-tabs": "0.0.1"
+    "react-native-tabs": "0.0.6"
   }
 }


### PR DESCRIPTION
Had the "Requiring unknown module react-native-tabs"-error due to an older version string in the package.json. 
It occured because the index.js has not been downloaded in the Example/node_modules/react-native-tabs package folder. Using the current version 0.0.6 I have no problems.
