### PR TITLE
Fix: set correct distinct key for TouchableOpacity

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ class Tabs extends Component {
         return (
             <View style={[styles.tabbarView, this.props.style]}>
                 {this.props.children.map((el)=>
-                    <TouchableOpacity key={el.key+"touch"} style={styles.iconView} onPress={()=>self.onSelect(el)}>
+                    <TouchableOpacity key={el.props.name+"touch"} style={styles.iconView} onPress={()=>self.onSelect(el)}>
                         {React.cloneElement(el, self.state[el.props.name])}
                     </TouchableOpacity>
                 )}


### PR DESCRIPTION
Fixes #4.

There's another problem which I've had on iOS as well:

```
<TouchableOpacity key={el.key+"touch"} style={styles.iconView} onPress={()=>self.onSelect(el)}>
    {React.cloneElement(el, self.state[el.props.name])}
</TouchableOpacity>
```

`el.key` is not defined which means that every Component gets the same key and react throws the following error:

> Warning: flattenChildren(...): Encountered two children with the same key, `.$nulltouch`. Child keys 
> must be unique; when two children share a key, only the first child will be used.

Therefore it should be:
`key={el.props.name+'touch'}`
