### PR TITLE
Add ability to "lock" tab buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ React Native platform-independent tabs. Could be used for bottom tab bars as wel
 Component just iterates over all its children and makes them touchable ('name' is only required attribute of each child).
 onSelect method should return changed properties of selected icon view - for example if icon view is a text, you could return {style: {color: 'red'}} to make that text red.
 For more complex cases (like different views for selected/unselected) you could just return {selected: true} and define different views within your icon class depending from its selected property.
+You can lock tab buttons (require user to use long press to actuate the button) by passing prop {locked: true}.
 
 ## Example
 Example makes selected icon color red and change the state of example view. To switch to other views you may use react-native-router-flux component or own navigation controller

--- a/index.js
+++ b/index.js
@@ -60,7 +60,7 @@ class Tabs extends Component {
         return (
             <View style={[styles.tabbarView, this.props.style]}>
                 {this.props.children.map((el)=>
-                    <TouchableOpacity key={el.key+"touch"} style={styles.iconView} onPress={()=>self.onSelect(el)}>
+                    <TouchableOpacity key={el.key+"touch"} style={styles.iconView} onPress={()=>!self.state.props.locked && self.onSelect(el)} onLongPress={()=>self.state.props.locked && self.onSelect(el)}>
                         {self.state.selected == el.props.name ? React.cloneElement(el, self.state.props) : el}
                     </TouchableOpacity>
                 )}

--- a/index.js
+++ b/index.js
@@ -26,8 +26,9 @@ class Tabs extends Component {
         this.setState({selected: el.props.name, props});
     }
 
-    componentWillReceiveProps({selected, props}){
+    componentWillReceiveProps({selected, ...props}){
         //console.log("TABS SELECTED:"+selected);
+        //console.log("TABBAR locked", props.locked);
         let myProps = {selected: true, ...props};
         this.setState({selected, props: myProps});
     }


### PR DESCRIPTION
Passing a `locked` prop to the Tab component, disables tab actuation by a simple press --- the user must use a long press to actuate it. Useful when the user wants to prevent switching away from an important screen when a button is accidentally touched.

This PR also fixes an error in parameter destructuring which prevented additional props from being passed to the tab.
