### PR TITLE
Fix element prop updates

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,7 @@ class Tabs extends Component {
                        style={[styles.iconView, this.props.iconStyle]} 
                        onPress={()=>!self.props.locked && self.onSelect(el)} 
                        onLongPress={()=>self.props.locked && self.onSelect(el)}>
-                         {!self.props.selected && (self.state.selected == el.props.name) ? React.cloneElement(el, self.state.props) : el}
+                         {(self.state.selected == el.props.name) ? React.cloneElement(el, self.state.props) : el}
                     </TouchableOpacity>
                 )}
             </View>


### PR DESCRIPTION
Not sure why it was there, but this check breaks prop updates for children if the `selected` prop is set

This fixes the problem but I'm not absolutely certain that it doesn't break anything else
