### PR TITLE
remove opacity for tab button

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ class Tabs extends Component {
         return (
             <View style={[styles.tabbarView, this.props.style]}>
                 {React.Children.map(this.props.children.filter(c=>c),(el)=>
-                    <TouchableOpacity key={el.props.name+"touch"}
+                    <TouchableOpacity activeOpacity={1} key={el.props.name+"touch"}
                        style={[styles.iconView, this.props.iconStyle, el.props.name == selected ? this.props.selectedIconStyle || el.props.selectedIconStyle || {} : {} ]}
                        onPress={()=>!self.props.locked && self.onSelect(el)}
                        onLongPress={()=>self.props.locked && self.onSelect(el)}>


### PR DESCRIPTION
I find iOS doesn't have opacity effect on tabs, therefore change alpha to 1.
How about using TouchableNativeFeedback for android?
