### PR TITLE
Conform to new version of React/React Native

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,15 @@
 'use strict';
 
-var React = require('react-native');
-var {
-    Component,
+import React, {
+    Component
+} from 'react';
+
+import {
     StyleSheet,
     View,
     Text,
     TouchableOpacity,
-} = React;
+} from 'react-native';
 
 class Tabs extends Component {
     onSelect(el){


### PR DESCRIPTION
In the new versions of React native (0.25) it's deprecated to get Component and React from react-native package.
