### PR TITLE
Long press can also activate not-locked tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ class Tabs extends Component {
                     <TouchableOpacity key={el.props.name+"touch"}
                        style={[styles.iconView, this.props.iconStyle, (el.props.name || el.key) == selected ? this.props.selectedIconStyle || el.props.selectedIconStyle || {} : {} ]}
                        onPress={()=>!self.props.locked && self.onSelect(el)}
-                       onLongPress={()=>self.props.locked && self.onSelect(el)}>
+                       onLongPress={()=>self.onSelect(el)}>
                          {selected == (el.props.name || el.key) ? React.cloneElement(el, {selected: true, style: [el.props.style, this.props.selectedStyle, el.props.selectedStyle]}) : el}
                     </TouchableOpacity>
                 )}


### PR DESCRIPTION
I think a long press gesture on a tab item should activate the tab no matter the tab item is locked or not
