### PR TITLE
OnPress opacity changed

### DIFF
--- a/Example/index.ios.js
+++ b/Example/index.ios.js
@@ -23,7 +23,8 @@ class Example extends React.Component {
     return (
       <View style={styles.container}>
         <Tabs selected={this.state.page} style={{backgroundColor:'white'}}
-              selectedStyle={{color:'red'}} onSelect={el=>this.setState({page:el.props.name})}>
+              selectedStyle={{color:'red'}} onSelect={el=>this.setState({page:el.props.name})}
+              pressOpacity={1}>
             <Text name="first">First</Text>
             <Text name="second" selectedIconStyle={{borderTopWidth:2,borderTopColor:'red'}}>Second</Text>
             <Text name="third">Third</Text>

--- a/Example/package.json
+++ b/Example/package.json
@@ -7,6 +7,6 @@
   },
   "dependencies": {
     "react-native": "^0.20.0",
-    "react-native-tabs": "^1.0.3"
+    "react-native-tabs": "file:../"
   }
 }

--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ class Tabs extends Component {
                        style={[styles.iconView, this.props.iconStyle, (el.props.name || el.key) == selected ? this.props.selectedIconStyle || el.props.selectedIconStyle || {} : {} ]}
                        onPress={()=>!self.props.locked && self.onSelect(el)}
                        onLongPress={()=>self.onSelect(el)}
-                       activeOpacity={1}>
+                       activeOpacity={el.props.pressOpacity}>
                          {selected == (el.props.name || el.key) ? React.cloneElement(el, {selected: true, style: [el.props.style, this.props.selectedStyle, el.props.selectedStyle]}) : el}
                     </TouchableOpacity>
                 )}

--- a/index.js
+++ b/index.js
@@ -36,7 +36,8 @@ class Tabs extends Component {
                     <TouchableOpacity key={el.props.name+"touch"}
                        style={[styles.iconView, this.props.iconStyle, (el.props.name || el.key) == selected ? this.props.selectedIconStyle || el.props.selectedIconStyle || {} : {} ]}
                        onPress={()=>!self.props.locked && self.onSelect(el)}
-                       onLongPress={()=>self.onSelect(el)}>
+                       onLongPress={()=>self.onSelect(el)}
+                       activeOpacity={1}>
                          {selected == (el.props.name || el.key) ? React.cloneElement(el, {selected: true, style: [el.props.style, this.props.selectedStyle, el.props.selectedStyle]}) : el}
                     </TouchableOpacity>
                 )}


### PR DESCRIPTION
Hey !

I've removed the opacity when you click on a TabIcon to look like the real iOS Tab Bar.
