### PR TITLE
Fix. setState() can only update a mounted component

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,14 @@ class Tabs extends Component {
 
     componentWillMount(){
         if (Platform.OS==='android') {
-            Keyboard.addListener('keyboardDidShow', this.keyboardWillShow);
-            Keyboard.addListener('keyboardDidHide', this.keyboardWillHide);
+            this.keyboardDidShowListener = Keyboard.addListener('keyboardDidShow', this.keyboardWillShow);
+            this.keyboardDidHideListener = Keyboard.addListener('keyboardDidHide', this.keyboardWillHide);
         }
+    }
+
+    componentWillUnmount(){
+        this.keyboardDidShowListener.remove();
+        this.keyboardDidHideListener.remove();
     }
 
     keyboardWillShow = (e) => {


### PR DESCRIPTION
hideTabBar unmounts tabs, but keyboard is still listening for the events. 
This will remove the warning.
