### PR TITLE
Ignore onSelect if selected tab is same and this tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,9 @@ class Tabs extends Component {
     state: State = {};
 
     onSelect(el){
+        if (el.props.name === this.props.selected) {
+            // do nothing since still on the same tab
+        }
         if (el.props.onSelect) {
             el.props.onSelect(el);
         } else if (this.props.onSelect) {


### PR DESCRIPTION
This should fix an issue where the tab sometimes re-renders when pressing the current tab. I could change this to a boolean prop if for some reason people want the tab to re-render.