### PR TITLE
Remove the obsolete `this` reference in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ class Example extends Component {
     this.state = {page:'second'};
   }
   render() {
-    var self = this;
     return (
       <View style={styles.container}>
         <Tabs selected={this.state.page} style={{backgroundColor:'white'}}


### PR DESCRIPTION
I was trying to find out what this `var` declaration does, but it seems like it was survived from some copypasta [here](https://github.com/aksonov/react-native-tabs/blob/098b79615031a1825cfe984a1c862327f67dd831/index.js). Not sure if I'm missing something here - but if not, I suppose we could safely remove this?