### PR TITLE
Component Unmount Error in iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+## [SOLVED]Component Unmount Error in iOS
+
 # react-native-tabs
 React Native platform-independent tabs. Could be used for bottom tab bars as well as sectioned views (with tab buttons)
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,1 @@
+theme: jekyll-theme-minimal

--- a/index.js
+++ b/index.js
@@ -36,8 +36,10 @@ class Tabs extends Component {
     }
 
     componentWillUnmount(){
-        this.keyboardDidShowListener.remove();
-        this.keyboardDidHideListener.remove();
+        if (Platform.OS==='android') {
+            this.keyboardDidShowListener.remove();
+            this.keyboardDidHideListener.remove();
+        }
     }
 
     keyboardWillShow = (e) => {


### PR DESCRIPTION
There was problem in event listener while component is unmounting.
I was trying to hide tabs in iOS programatically and it leads  me error because it is not finding any method like .remove()  because it is not added for iOS as code is for adding event is for android only.